### PR TITLE
CLOUD-537 - Added autoStart property checking

### DIFF
--- a/content/PowershellModules/WebInstallation.psm1
+++ b/content/PowershellModules/WebInstallation.psm1
@@ -241,6 +241,10 @@ function Install-ApplicationPool {
 	
 	Write-Log "Creating applicationPool $($appPoolConfig.name)"
 	$appPool = New-WebAppPool -Name $appPoolConfig.name
+
+	if ($appPoolConfig.autoStart -eq $false) {
+		Stop-WebAppPool -Name $appPoolConfig.name
+	}
 	
 	$appPool.enable32BitAppOnWin64 = $appPoolConfig.enable32Bit
 	$appPool.managedRuntimeVersion = $appPoolConfig.frameworkVersion

--- a/content/PowershellModules/configuration.xsd
+++ b/content/PowershellModules/configuration.xsd
@@ -1026,6 +1026,7 @@
       <xs:element name="properties" type="appPoolProperties" minOccurs="0" maxOccurs="1" />
     </xs:all>
     <xs:attribute name="name" use="required" />
+    <xs:attribute name="autoStart" type="xs:boolean" default="true" />
     <xs:attribute name="frameworkVersion" type="frameworkVersion" default="v4.0" />
     <xs:attribute name="enable32Bit" type="xs:boolean" default="false" />
     <xs:attribute name="managedPipelineMode" type="managedPipelineMode" default="Integrated" />


### PR DESCRIPTION
This change checks for "autoStart" property (which is added to appPool tag in configuration.xml).
if it is set to false it stops the created AppPool right after creating it, otherwise (even true or not set), the behavior is like before, so this change is backward compatible.